### PR TITLE
allow actual regexp matching instead of exact non-regexp match

### DIFF
--- a/ctypeslib/codegen/codegenerator.py
+++ b/ctypeslib/codegen/codegenerator.py
@@ -897,10 +897,16 @@ def generate_code(srcfiles,
                 if i.name is None:
                     continue
                 match = s.match(i.name)
-                # we only want complete matches
+                # if we only want complete matches:
                 if match and match.group() == i.name:
                     todo.append(i)
                     break
+                # if we follow our own documentation, 
+                # allow regular expression match of any part of name:
+                match = s.search(i.name)
+                if match:
+                     todo.append(i)
+                     break
     if symbols or expressions:
         items = todo
 


### PR DESCRIPTION
This is a minor addition, fixing https://bugs.python.org/issue24880

The ctypeslib usage says that "-r EXPRESSION regular expression for symbols to include". But behaviour did not match documentation. The fix here allows *actually* using regular expressions.

Before, when the expression was evaluated, only exact name matches were actually selected. For example, -r "set" would match just one C/C++ function named exactly "set". Any wildcards, regexps did not work. 
