### PR TITLE
Allow more then one match when testing expressions

### DIFF
--- a/ctypeslib/codegen/codegenerator.py
+++ b/ctypeslib/codegen/codegenerator.py
@@ -916,13 +916,13 @@ def generate_code(srcfiles,
                 # if we only want complete matches:
                 if match and match.group() == i.name:
                     todo.append(i)
-                    break
+                    continue
                 # if we follow our own documentation,
                 # allow regular expression match of any part of name:
                 match = s.search(i.name)
                 if match:
                      todo.append(i)
-                     break
+                     continue
     if symbols or expressions:
         items = todo
 


### PR DESCRIPTION
At the moment if you supply a regular expression match, even `clang2py -r '.*'` it can only ever match one symbol.