### PR TITLE
Use function provided argv in clang2py main

### DIFF
--- a/ctypeslib/clang2py.py
+++ b/ctypeslib/clang2py.py
@@ -204,7 +204,7 @@ def main(argv=None):
     parser.epilog = """Cross-architecture: You can pass target modifiers to clang.
     For example, try --clang-args="-target x86_64" or "-target i386-linux" to change the target CPU arch."""
 
-    options = parser.parse_args()
+    options = parser.parse_args(argv)
 
     # handle stdin, just in case
     files = []


### PR DESCRIPTION
The main() function of clang2py which accepts an optional argv argument instead of sys.argv, but does not use it.  This change passes argv into argparse.parse_args so it will be used if present.