### PR TITLE
MANIFEST.in: Include everything

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,14 @@
-include README.md
+include README.md CHANGES.md
 include LICENSE.txt
+include requirements.txt
+include TODO
+include ctypeslib/experimental/README.txt
+recursive-include ctypeslib *.py
+recursive-include docs *.*
+recursive-include test *.py
+recursive-include test *.c
+recursive-include test *.cpp
+recursive-include test *.h
+
+# added by check_manifest.py
+include *.txt


### PR DESCRIPTION
test/__init__.py is especially needed, but most other files
are useful for packagers.

Fixes https://github.com/trolldbois/ctypeslib/issues/58