### PR TITLE
On duplicate definition, return definition instead of raising exception

### DIFF
--- a/ctypeslib/codegen/clangparser.py
+++ b/ctypeslib/codegen/clangparser.py
@@ -177,8 +177,9 @@ class Clang_Parser(object):
         if name in self.all:
             log.debug('register: %s already existed: %s', name, obj.name)
             # code.interact(local=locals())
-            raise DuplicateDefinitionException(
-                'register: %s already existed: %s' % (name, obj.name))
+            #raise DuplicateDefinitionException(
+            #    'register: %s already existed: %s' % (name, obj.name))
+            return self.all[name]
         log.debug('register: %s ', name)
         self.all[name] = obj
         return obj


### PR DESCRIPTION
Trying to generate binding for ffmpeg, give me some errors like:

ctypeslib.codegen.handler.DuplicateDefinitionException: 'register: struct_AVCodecDefault already existed: struct_AVCodecDefault'

Let me know if a proper fix can be done or if I can improve anything.
