### PR TITLE
Use libclang installed with commandline tools on macos

### DIFF
--- a/ctypeslib/__init__.py
+++ b/ctypeslib/__init__.py
@@ -35,7 +35,7 @@ try:
         if os.name == "posix" and sys.platform == "darwin":
             # On darwin, consider that Xcode should be installed in its default path.
             from clang import cindex
-            cindex.Config.set_library_file('/Applications/Xcode.app/Contents/Frameworks/libclang.dylib')
+            cindex.Config.set_library_file('/Library/Developer/CommandLineTools/usr/lib/libclang.dylib')
 
     def clang_version():
         return cindex.Config.library_file

--- a/ctypeslib/__init__.py
+++ b/ctypeslib/__init__.py
@@ -33,7 +33,7 @@ try:
             break
     else:
         if os.name == "posix" and sys.platform == "darwin":
-            # On darwin, consider that Xcode should be installed in its default path.
+            # On darwin, assume that users have installed commandline tools.
             from clang import cindex
             cindex.Config.set_library_file('/Library/Developer/CommandLineTools/usr/lib/libclang.dylib')
 


### PR DESCRIPTION
libclang is bundled with commandline tools on darwin, which doesn't need Xcode.