### PR TITLE
Fix enum size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ dist
 *~
 *.pyc
 ctypeslib.egg-info/
+ctypeslib2.egg-info/
 *.gitignore~

--- a/test/data/test-enum.c
+++ b/test/data/test-enum.c
@@ -4,18 +4,3 @@ ONE,
 TWO,
 FOUR = 4
 };
-
-enum myEnum_byte {
-MY_ENUM_BYTE_ZERO,
-MY_ENUM_BYTE_MAX=0xFF
-};
-
-enum myEnum_int16 {
-MY_ENUM_INT16_ZERO,
-MY_ENUM_INT16_MAX=0xFFFF
-};
-
-enum myEnum_int32 {
-MY_ENUM_INT32_ZERO,
-MY_ENUM_INT32_MAX=0xFFFFFFFF
-};

--- a/test/data/test-enum.c
+++ b/test/data/test-enum.c
@@ -4,3 +4,18 @@ ONE,
 TWO,
 FOUR = 4
 };
+
+enum myEnum_byte {
+MY_ENUM_BYTE_ZERO,
+MY_ENUM_BYTE_MAX=0xFF
+};
+
+enum myEnum_int16 {
+MY_ENUM_INT16_ZERO,
+MY_ENUM_INT16_MAX=0xFFFF
+};
+
+enum myEnum_int32 {
+MY_ENUM_INT32_ZERO,
+MY_ENUM_INT32_MAX=0xFFFFFFFF
+};

--- a/test/test_enum.py
+++ b/test/test_enum.py
@@ -19,6 +19,53 @@ class EnumTest(ClangTest):
         self.assertEqual(self.namespace.ONE, 1)
         self.assertEqual(self.namespace.FOUR, 4)
 
+    def test_enum_short_option(self):
+        """
+        Enums can be forced to occupy less space than an int if possible:
+          1) Add the attribute `__attribute__((__packed__))` to the C variable declarations
+          2) Set the compiler flag ` CFLAGS += -fshort-enums`
+        In any case, we should trust the enum size returned by the compiler.
+        """
+        flags = ['-target', 'i386-linux', '-fshort-enums']
+        self.gen('test/data/test-enum.c', flags)
+
+        # Expect enum stored as 1 byte
+        self.assertEqual(ctypes.sizeof(self.namespace.myEnum_byte), 1)
+        self.assertEqual(self.namespace.MY_ENUM_BYTE_ZERO, 0)
+        self.assertEqual(self.namespace.MY_ENUM_BYTE_MAX, 0xFF)
+
+        # Expect enum stored in 2 bytes
+        self.assertEqual(ctypes.sizeof(self.namespace.myEnum_int16), 2)
+        self.assertEqual(self.namespace.MY_ENUM_INT16_ZERO, 0)
+        self.assertEqual(self.namespace.MY_ENUM_INT16_MAX, 0xFFFF)
+
+        # Expect enum stored in 4 bytes
+        self.assertEqual(ctypes.sizeof(self.namespace.myEnum_int32), 4)
+        self.assertEqual(self.namespace.MY_ENUM_INT32_ZERO, 0)
+        self.assertEqual(self.namespace.MY_ENUM_INT32_MAX, 0xFFFFFFFF)
+
+    def test_enum_no_short_option(self):
+        """
+        By default, enums are stored as 'int', so they will occupy 4 bytes.
+        """
+        flags = ['-target', 'i386-linux']
+        self.gen('test/data/test-enum.c', flags)
+
+        # Expect enum stored as 'int'
+        self.assertEqual(ctypes.sizeof(self.namespace.myEnum_byte), 4)
+        self.assertEqual(self.namespace.MY_ENUM_BYTE_ZERO, 0)
+        self.assertEqual(self.namespace.MY_ENUM_BYTE_MAX, 0xFF)
+
+        # Expect enum stored as 'int'
+        self.assertEqual(ctypes.sizeof(self.namespace.myEnum_int16), 4)
+        self.assertEqual(self.namespace.MY_ENUM_INT16_ZERO, 0)
+        self.assertEqual(self.namespace.MY_ENUM_INT16_MAX, 0xFFFF)
+
+        # Expect enum stored as 'int'
+        self.assertEqual(ctypes.sizeof(self.namespace.myEnum_int32), 4)
+        self.assertEqual(self.namespace.MY_ENUM_INT32_ZERO, 0)
+        self.assertEqual(self.namespace.MY_ENUM_INT32_MAX, 0xFFFFFFFF)
+
 
 if __name__ == "__main__":
     # logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)

--- a/test/test_enum.py
+++ b/test/test_enum.py
@@ -19,7 +19,7 @@ class EnumTest(ClangTest):
         self.assertEqual(self.namespace.ONE, 1)
         self.assertEqual(self.namespace.FOUR, 4)
 
-    def test_enum_short_option(self):
+    def test_enum_short_option_uint8(self):
         """
         Enums can be forced to occupy less space than an int if possible:
           1) Add the attribute `__attribute__((__packed__))` to the C variable declarations
@@ -27,44 +27,123 @@ class EnumTest(ClangTest):
         In any case, we should trust the enum size returned by the compiler.
         """
         flags = ['-target', 'i386-linux', '-fshort-enums']
-        self.gen('test/data/test-enum.c', flags)
+        self.convert(
+            '''
+        enum myEnum {
+            MIN=0,   /* UINT8_MIN */
+            MAX=0xFF /* UINT8_MAX */
+        };
+        ''', flags)
 
         # Expect enum stored as 1 byte
-        self.assertEqual(ctypes.sizeof(self.namespace.myEnum_byte), 1)
-        self.assertEqual(self.namespace.MY_ENUM_BYTE_ZERO, 0)
-        self.assertEqual(self.namespace.MY_ENUM_BYTE_MAX, 0xFF)
+        self.assertEqual(ctypes.sizeof(self.namespace.myEnum), 1)
+        self.assertEqual(self.namespace.MIN, 0)
+        self.assertEqual(self.namespace.MAX, 0xFF)
 
-        # Expect enum stored in 2 bytes
-        self.assertEqual(ctypes.sizeof(self.namespace.myEnum_int16), 2)
-        self.assertEqual(self.namespace.MY_ENUM_INT16_ZERO, 0)
-        self.assertEqual(self.namespace.MY_ENUM_INT16_MAX, 0xFFFF)
-
-        # Expect enum stored in 4 bytes
-        self.assertEqual(ctypes.sizeof(self.namespace.myEnum_int32), 4)
-        self.assertEqual(self.namespace.MY_ENUM_INT32_ZERO, 0)
-        self.assertEqual(self.namespace.MY_ENUM_INT32_MAX, 0xFFFFFFFF)
-
-    def test_enum_no_short_option(self):
+    def test_enum_short_option_uint16(self):
         """
-        By default, enums are stored as 'int', so they will occupy 4 bytes.
+        Enums can be forced to occupy less space than an int if possible:
+          1) Add the attribute `__attribute__((__packed__))` to the C variable declarations
+          2) Set the compiler flag ` CFLAGS += -fshort-enums`
+        In any case, we should trust the enum size returned by the compiler.
         """
-        flags = ['-target', 'i386-linux']
-        self.gen('test/data/test-enum.c', flags)
+        flags = ['-target', 'i386-linux', '-fshort-enums']
+        self.convert(
+            '''
+        enum myEnum {
+            MIN=0,      /* UINT16_MIN */
+            MAX=0xFFFF  /* UINT16_MAX */
+        };
+        ''', flags)
 
-        # Expect enum stored as 'int'
-        self.assertEqual(ctypes.sizeof(self.namespace.myEnum_byte), 4)
-        self.assertEqual(self.namespace.MY_ENUM_BYTE_ZERO, 0)
-        self.assertEqual(self.namespace.MY_ENUM_BYTE_MAX, 0xFF)
+        # Expect enum stored as 1 byte
+        self.assertEqual(ctypes.sizeof(self.namespace.myEnum), 2)
+        self.assertEqual(self.namespace.MIN, 0)
+        self.assertEqual(self.namespace.MAX, 0xFFFF)
 
-        # Expect enum stored as 'int'
-        self.assertEqual(ctypes.sizeof(self.namespace.myEnum_int16), 4)
-        self.assertEqual(self.namespace.MY_ENUM_INT16_ZERO, 0)
-        self.assertEqual(self.namespace.MY_ENUM_INT16_MAX, 0xFFFF)
+    def test_enum_short_option_uint32(self):
+        """
+        Enums can be forced to occupy less space than an int if possible:
+          1) Add the attribute `__attribute__((__packed__))` to the C variable declarations
+          2) Set the compiler flag ` CFLAGS += -fshort-enums`
+        In any case, we should trust the enum size returned by the compiler.
+        """
+        flags = ['-target', 'i386-linux', '-fshort-enums']
+        self.convert(
+            '''
+        enum myEnum {
+            MIN=0,          /* UINT32_MIN */
+            MAX=0xFFFFFFFF  /* UINT32_MAX */
+        };
+        ''', flags)
 
-        # Expect enum stored as 'int'
-        self.assertEqual(ctypes.sizeof(self.namespace.myEnum_int32), 4)
-        self.assertEqual(self.namespace.MY_ENUM_INT32_ZERO, 0)
-        self.assertEqual(self.namespace.MY_ENUM_INT32_MAX, 0xFFFFFFFF)
+        # Expect enum stored as 1 byte
+        self.assertEqual(ctypes.sizeof(self.namespace.myEnum), 4)
+        self.assertEqual(self.namespace.MIN, 0)
+        self.assertEqual(self.namespace.MAX, 0xFFFFFFFF)
+
+    def test_enum_short_option_int8(self):
+        """
+        Enums can be forced to occupy less space than an int if possible:
+          1) Add the attribute `__attribute__((__packed__))` to the C variable declarations
+          2) Set the compiler flag ` CFLAGS += -fshort-enums`
+        In any case, we should trust the enum size returned by the compiler.
+        """
+        flags = ['-target', 'i386-linux', '-fshort-enums']
+        self.convert(
+            '''
+        enum myEnum {
+            MIN=-128, /* INT8_MIN */
+            MAX= 127  /* INT8_MAX */
+        };
+        ''', flags)
+
+        # Expect enum stored as 1 byte
+        self.assertEqual(ctypes.sizeof(self.namespace.myEnum), 1)
+        self.assertEqual(self.namespace.MIN, -128)
+        self.assertEqual(self.namespace.MAX, 127)
+
+    def test_enum_short_option_int16(self):
+        """
+        Enums can be forced to occupy less space than an int if possible:
+          1) Add the attribute `__attribute__((__packed__))` to the C variable declarations
+          2) Set the compiler flag ` CFLAGS += -fshort-enums`
+        In any case, we should trust the enum size returned by the compiler.
+        """
+        flags = ['-target', 'i386-linux', '-fshort-enums']
+        self.convert(
+            '''
+        enum myEnum {
+            MIN=-32768, /* INT16_MIN */
+            MAX= 32767  /* INT16_MAX*/
+        };
+        ''', flags)
+
+        # Expect enum stored as 1 byte
+        self.assertEqual(ctypes.sizeof(self.namespace.myEnum), 2)
+        self.assertEqual(self.namespace.MIN, -32768)
+        self.assertEqual(self.namespace.MAX, 32767)
+
+    def test_enum_short_option_int32(self):
+        """
+        Enums can be forced to occupy less space than an int if possible:
+          1) Add the attribute `__attribute__((__packed__))` to the C variable declarations
+          2) Set the compiler flag ` CFLAGS += -fshort-enums`
+        In any case, we should trust the enum size returned by the compiler.
+        """
+        flags = ['-target', 'i386-linux', '-fshort-enums']
+        self.convert(
+            '''
+        enum myEnum {
+            MIN=-65536, /* INT32_MIN */
+            MAX= 65535  /* INT32_MAX*/
+        };
+        ''', flags)
+
+        # Expect enum stored as 1 byte
+        self.assertEqual(ctypes.sizeof(self.namespace.myEnum), 4)
+        self.assertEqual(self.namespace.MIN, -65536)
+        self.assertEqual(self.namespace.MAX, 65535)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Fix non-default enum size

**TL;DR: Enums can be forced to occupy less space than an int if possible.** This fix adjusts the enum size based on the information returned by the compiler.

# Intro

Hi @trolldbois, thanks for your amazing work!  
I am  usually using `ctypeslib` in small embedded devices constrained by code size and I/O throughput. For those application, it may be desirable to have the compiler generating `enum`s that occupy less than the default `int` size (see how below).

During my work, I noticed that the Python code generator will always produce a enumeration type as `ctypes.c_int` ([codegenerator.py#L465](https://github.com/trolldbois/ctypeslib/blob/8d9ef5a06fd3479d747190cd2339ffbf6f2ef301/ctypeslib/codegen/codegenerator.py#L465)).  
The compiler output gives us the size of each enum in byte, and this information is already available in the function where the issue occurs.  I believe that in any case, we should trust the enum size returned by the compiler.

# How enum can occupy less space?

Enum size is not defined in the C norm. This is entirely up to the compiler to choose.

## Setup

GGC compiler has a flag that allow it to select the minimum type size: 1, 2 or 4 bytes (maybe more on 64-bit system?)
Set the compiler flag `-fshort-enums`, either via `CFLAGS` environment variable or as parser argument flag (like in the Unit Tests).

```
flags = ['-fshort-enums']
self.convert(
'''
enum myEnum {
    MIN=0,   /* UINT8_MIN */
    MAX=0xFF /* UINT8_MAX */
};
'', flags)
```

## Expected behavior

`myEnum` is converted to Python as 1-byte ctype type:  `ctypes.c_byte`.

## Current behavior

`myEnum` is converted to Python as 4-byte ctype type:  `ctypes.c_int`, whereas the C implementation expects 1 byte. The Python enum size is then larger than the C code one.

## Note

There must be a better way to [code the mapping](https://github.com/trolldbois/ctypeslib/compare/master...rviollette:fix-enum-size?expand=1#diff-c6dfa367b63cb77a90ab0e79c060eaac100084087be96790f5b3d0e4a8639256R470) the enum size [1,2,4] to the corresponding ctype. I did not spend too much time on that aspect.

# References

https://stackoverflow.com/a/54527229/1641819
https://stackoverflow.com/a/56432050/1641819