### PR TITLE
Fix enum signedness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist
 ctypeslib.egg-info/
 ctypeslib2.egg-info/
 *.gitignore~
+*.so

--- a/test/test_enum.py
+++ b/test/test_enum.py
@@ -21,129 +21,155 @@ class EnumTest(ClangTest):
 
     def test_enum_short_option_uint8(self):
         """
-        Enums can be forced to occupy less space than an int if possible:
-          1) Add the attribute `__attribute__((__packed__))` to the C variable declarations
-          2) Set the compiler flag ` CFLAGS += -fshort-enums`
-        In any case, we should trust the enum size returned by the compiler.
+        Test the enum size when compiler flag '-fshort-enums' is used.
+        Test the signedness of the enum, based on the sign of the values it contains.
         """
-        flags = ['-target', 'i386-linux', '-fshort-enums']
+        flags = ['-fshort-enums']
         self.convert(
             '''
         enum myEnum {
-            MIN=0,   /* UINT8_MIN */
-            MAX=0xFF /* UINT8_MAX */
+            MIN = 0,   /* UINT8_MIN */
+            MAX = 0xFF /* UINT8_MAX */
         };
         ''', flags)
 
-        # Expect enum stored as 1 byte
         self.assertEqual(ctypes.sizeof(self.namespace.myEnum), 1)
+        self.assertEqual(self.namespace.myEnum, ctypes.c_uint8)
         self.assertEqual(self.namespace.MIN, 0)
         self.assertEqual(self.namespace.MAX, 0xFF)
 
     def test_enum_short_option_uint16(self):
         """
-        Enums can be forced to occupy less space than an int if possible:
-          1) Add the attribute `__attribute__((__packed__))` to the C variable declarations
-          2) Set the compiler flag ` CFLAGS += -fshort-enums`
-        In any case, we should trust the enum size returned by the compiler.
+        Test the enum size when compiler flag '-fshort-enums' is used.
+        Test the signedness of the enum, based on the sign of the values it contains.
         """
-        flags = ['-target', 'i386-linux', '-fshort-enums']
+        flags = ['-fshort-enums']
         self.convert(
             '''
         enum myEnum {
-            MIN=0,      /* UINT16_MIN */
-            MAX=0xFFFF  /* UINT16_MAX */
+            MIN = 0,      /* UINT16_MIN */
+            MAX = 0xFFFF  /* UINT16_MAX */
         };
         ''', flags)
 
-        # Expect enum stored as 1 byte
         self.assertEqual(ctypes.sizeof(self.namespace.myEnum), 2)
+        self.assertEqual(self.namespace.myEnum, ctypes.c_uint16)
         self.assertEqual(self.namespace.MIN, 0)
         self.assertEqual(self.namespace.MAX, 0xFFFF)
 
     def test_enum_short_option_uint32(self):
         """
-        Enums can be forced to occupy less space than an int if possible:
-          1) Add the attribute `__attribute__((__packed__))` to the C variable declarations
-          2) Set the compiler flag ` CFLAGS += -fshort-enums`
-        In any case, we should trust the enum size returned by the compiler.
+        Test the enum size when compiler flag '-fshort-enums' is used.
+        Test the signedness of the enum, based on the sign of the values it contains.
         """
-        flags = ['-target', 'i386-linux', '-fshort-enums']
+        flags = ['-fshort-enums']
         self.convert(
             '''
         enum myEnum {
-            MIN=0,          /* UINT32_MIN */
-            MAX=0xFFFFFFFF  /* UINT32_MAX */
+            MIN = 0,          /* UINT32_MIN */
+            MAX = 0xFFFFFFFF  /* UINT32_MAX */
         };
         ''', flags)
 
-        # Expect enum stored as 1 byte
         self.assertEqual(ctypes.sizeof(self.namespace.myEnum), 4)
+        self.assertEqual(self.namespace.myEnum, ctypes.c_uint32)
         self.assertEqual(self.namespace.MIN, 0)
         self.assertEqual(self.namespace.MAX, 0xFFFFFFFF)
 
-    def test_enum_short_option_int8(self):
+    def test_enum_short_option_uint64(self):
         """
-        Enums can be forced to occupy less space than an int if possible:
-          1) Add the attribute `__attribute__((__packed__))` to the C variable declarations
-          2) Set the compiler flag ` CFLAGS += -fshort-enums`
-        In any case, we should trust the enum size returned by the compiler.
+        Test the enum size when compiler flag '-fshort-enums' is used.
+        Test the signedness of the enum, based on the sign of the values it contains.
         """
-        flags = ['-target', 'i386-linux', '-fshort-enums']
+        flags = ['-fshort-enums']
         self.convert(
             '''
         enum myEnum {
-            MIN=-128, /* INT8_MIN */
-            MAX= 127  /* INT8_MAX */
+            MIN = 0,                  /* UINT64_MIN */
+            MAX = 0xFFFFFFFFFFFFFFFF  /* UINT64_MAX*/
         };
         ''', flags)
 
-        # Expect enum stored as 1 byte
+        self.assertEqual(ctypes.sizeof(self.namespace.myEnum), 8)
+        self.assertEqual(self.namespace.myEnum, ctypes.c_uint64)
+        self.assertEqual(self.namespace.MIN, 0)
+        self.assertEqual(self.namespace.MAX, 0xFFFFFFFFFFFFFFFF)
+
+    def test_enum_short_option_int8(self):
+        """
+        Test the enum size when compiler flag '-fshort-enums' is used.
+        Test the signedness of the enum, based on the sign of the values it contains.
+        """
+        flags = ['-fshort-enums']
+        self.convert(
+            '''
+        enum myEnum {
+            MIN = (-0x7F - 1), /* INT8_MIN */
+            MAX =   0x7F       /* INT8_MAX */
+        };
+        ''', flags)
+
         self.assertEqual(ctypes.sizeof(self.namespace.myEnum), 1)
-        self.assertEqual(self.namespace.MIN, -128)
-        self.assertEqual(self.namespace.MAX, 127)
+        self.assertEqual(self.namespace.myEnum, ctypes.c_int8)
+        self.assertEqual(self.namespace.MIN, (-0x7F - 1))
+        self.assertEqual(self.namespace.MAX,   0x7F)
 
     def test_enum_short_option_int16(self):
         """
-        Enums can be forced to occupy less space than an int if possible:
-          1) Add the attribute `__attribute__((__packed__))` to the C variable declarations
-          2) Set the compiler flag ` CFLAGS += -fshort-enums`
-        In any case, we should trust the enum size returned by the compiler.
+        Test the enum size when compiler flag '-fshort-enums' is used.
+        Test the signedness of the enum, based on the sign of the values it contains.
         """
-        flags = ['-target', 'i386-linux', '-fshort-enums']
+        flags = ['-fshort-enums']
         self.convert(
             '''
         enum myEnum {
-            MIN=-32768, /* INT16_MIN */
-            MAX= 32767  /* INT16_MAX*/
+            MIN = (-0x7FFF - 1), /* INT16_MIN */
+            MAX =   0x7FFF       /* INT16_MAX*/
         };
         ''', flags)
 
-        # Expect enum stored as 1 byte
         self.assertEqual(ctypes.sizeof(self.namespace.myEnum), 2)
-        self.assertEqual(self.namespace.MIN, -32768)
-        self.assertEqual(self.namespace.MAX, 32767)
+        self.assertEqual(self.namespace.myEnum, ctypes.c_int16)
+        self.assertEqual(self.namespace.MIN, (-0x7FFF - 1))
+        self.assertEqual(self.namespace.MAX,   0x7FFF)
 
     def test_enum_short_option_int32(self):
         """
-        Enums can be forced to occupy less space than an int if possible:
-          1) Add the attribute `__attribute__((__packed__))` to the C variable declarations
-          2) Set the compiler flag ` CFLAGS += -fshort-enums`
-        In any case, we should trust the enum size returned by the compiler.
+        Test the enum size when compiler flag '-fshort-enums' is used.
+        Test the signedness of the enum, based on the sign of the values it contains.
         """
-        flags = ['-target', 'i386-linux', '-fshort-enums']
+        flags = ['-fshort-enums']
         self.convert(
             '''
         enum myEnum {
-            MIN=-65536, /* INT32_MIN */
-            MAX= 65535  /* INT32_MAX*/
+            MIN = (-0x7FFFFFFF - 1), /* INT32_MIN */
+            MAX =   0x7FFFFFFF       /* INT32_MAX*/
         };
         ''', flags)
 
-        # Expect enum stored as 1 byte
         self.assertEqual(ctypes.sizeof(self.namespace.myEnum), 4)
-        self.assertEqual(self.namespace.MIN, -65536)
-        self.assertEqual(self.namespace.MAX, 65535)
+        self.assertEqual(self.namespace.myEnum, ctypes.c_int32)
+        self.assertEqual(self.namespace.MIN, (-0x7FFFFFFF - 1))
+        self.assertEqual(self.namespace.MAX,   0x7FFFFFFF)
+
+    def test_enum_short_option_int64(self):
+        """
+        Test the enum size when compiler flag '-fshort-enums' is used.
+        Test the signedness of the enum, based on the sign of the values it contains.
+        """
+        flags = ['-fshort-enums']
+        self.convert(
+            '''
+        enum myEnum {
+            MIN =(-0x7FFFFFFFFFFFFFFF - 1), /* INT64_MIN */
+            MAX =  0x7FFFFFFFFFFFFFFF       /* INT64_MAX*/
+        };
+        ''', flags)
+
+        self.assertEqual(ctypes.sizeof(self.namespace.myEnum), 8)
+        self.assertEqual(self.namespace.myEnum, ctypes.c_int64)
+        self.assertEqual(self.namespace.MIN, (-0x7FFFFFFFFFFFFFFF - 1))
+        self.assertEqual(self.namespace.MAX,   0x7FFFFFFFFFFFFFFF)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Fix enum, part 2

This is part 2 of PR #87, commit 60d796b1cc70b119e87889ce766ef2e45dbf4740.

## Issue
In some cases, the Python representation of an enum is wrong because of a signedness confusion.

Before this fix, the following situation:
     - compiler flag '-fshort-enums' is set,
     - an enum with size less than an int is produced,
     - all enum values are positive or null.
was suffering from sign confusion when accessing an enum value with the generated Python code.

Example: an enum entry with value 0xFF was read as -127 instead of 255. This is a signedness issue.

Typically the following Unit Test extract was failing on the last line:
```python
self.convert('enum myEnum { FOO = 12};', ['-fshort-enums'])
self.assertEqual(ctypes.sizeof(self.namespace.myEnum), 1)   # PASS: Expect 1-byte enum
self.assertEqual(self.namespace.myEnum, ctypes.c_uint8)     # FAIL: Expect c_uint8, got c_int8
my_enum = self.namespace.myEnum()
my_enum.value = 0xFF                         # Set a 1-byte value with the most significant bit set.
self.assertTrue(my_enum.value > 0)     # FAIL: Except positive value, got negative
```

## Expected behavior
In order to obtain a correct (un)signed representation in Python, the signedness of the enum is deduced from the sign of enum values.
Rationale: if there is not any negative value in the enum, then the resulting enum ctype should be unsigned.

Note: It appears that the clang parser is already determining the appropriate sign for each enum values.
We use that information to infer the global type of the enum.

## Addendum
Finally, this fix brings support for 8-byte enum, that were not covered in previous commit 60d796b1cc70b119e87889ce766ef2e45dbf4740

It is assumed for the Unit Test that the local compiler is able to handle 64-bit numbers. Otherwise we should detect the platform and skip the 64-bit test steps.

## Regression Tests
new Unit Tests:

1) Test matrix:
     - size of enum: 1, 2, 4, 8 bytes.
     - with/without compiler flag '-fshort-enums'
2) 64-bits enums