### PR TITLE
Fix typo for pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,4 +28,4 @@ exclude = '''
 max-line-length = 120
 
 [tool.coverage.run]
-relative_files = True
+relative_files = true


### PR DESCRIPTION
A typo which causes `pip install` to fail.

```
$ python3 -m pip install https://github.com/trolldbois/ctypeslib/archive/d59c5d4725ec0d40f134e2bb87b120ea73af88be.zip
Collecting https://github.com/trolldbois/ctypeslib/archive/d59c5d4725ec0d40f134e2bb87b120ea73af88be.zip
  Using cached https://github.com/trolldbois/ctypeslib/archive/d59c5d4725ec0d40f134e2bb87b120ea73af88be.zip
ERROR: Exception:
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/pip/_vendor/toml/decoder.py", line 510, in loads
    ret = decoder.load_line(line, currentlevel, multikey,
  File "/usr/local/lib/python3.8/site-packages/pip/_vendor/toml/decoder.py", line 777, in load_line
    value, vtype = self.load_value(pair[1], strictly_valid)
  File "/usr/local/lib/python3.8/site-packages/pip/_vendor/toml/decoder.py", line 905, in load_value
    raise ValueError("This float doesn't have a leading "
ValueError: This float doesn't have a leading digit

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/pip/_internal/cli/base_command.py", line 228, in _main
    status = self.run(options, args)
  File "/usr/local/lib/python3.8/site-packages/pip/_internal/cli/req_command.py", line 182, in wrapper
    return func(self, options, args)
  File "/usr/local/lib/python3.8/site-packages/pip/_internal/commands/install.py", line 323, in run
    requirement_set = resolver.resolve(
  File "/usr/local/lib/python3.8/site-packages/pip/_internal/resolution/legacy/resolver.py", line 183, in resolve
    discovered_reqs.extend(self._resolve_one(requirement_set, req))
  File "/usr/local/lib/python3.8/site-packages/pip/_internal/resolution/legacy/resolver.py", line 388, in _resolve_one
    abstract_dist = self._get_abstract_dist_for(req_to_install)
  File "/usr/local/lib/python3.8/site-packages/pip/_internal/resolution/legacy/resolver.py", line 340, in _get_abstract_dist_for
    abstract_dist = self.preparer.prepare_linked_requirement(req)
  File "/usr/local/lib/python3.8/site-packages/pip/_internal/operations/prepare.py", line 482, in prepare_linked_requirement
    abstract_dist = _get_prepared_distribution(
  File "/usr/local/lib/python3.8/site-packages/pip/_internal/operations/prepare.py", line 91, in _get_prepared_distribution
    abstract_dist.prepare_distribution_metadata(finder, build_isolation)
  File "/usr/local/lib/python3.8/site-packages/pip/_internal/distributions/sdist.py", line 33, in prepare_distribution_metadata
    self.req.load_pyproject_toml()
  File "/usr/local/lib/python3.8/site-packages/pip/_internal/req/req_install.py", line 504, in load_pyproject_toml
    pyproject_toml_data = load_pyproject_toml(
  File "/usr/local/lib/python3.8/site-packages/pip/_internal/pyproject.py", line 75, in load_pyproject_toml
    pp_toml = toml.load(f)
  File "/usr/local/lib/python3.8/site-packages/pip/_vendor/toml/decoder.py", line 156, in load
    return loads(f.read(), _dict, decoder)
  File "/usr/local/lib/python3.8/site-packages/pip/_vendor/toml/decoder.py", line 513, in loads
    raise TomlDecodeError(str(err), original, pos)
pip._vendor.toml.decoder.TomlDecodeError: This float doesn't have a leading digit (line 31 column 1 char 499)
```