### PR TITLE
Changed clang2py -h output in Python 3.10

### DIFF
--- a/test/test_clang2py.py
+++ b/test/test_clang2py.py
@@ -96,7 +96,7 @@ class ArgumentHelper(ClangTest):
         self.assertEqual(0, p.returncode)
         self.assertIn("Cross-architecture:", output)
         self.assertIn("usage:", output)
-        self.assertIn("optional arguments", output)
+        self.assertRegex(output, r"\noption.*:")
 
 
 class ArgumentTypeKind(ClangTest):


### PR DESCRIPTION
The  line for the argparser changed from "optional arguments" to "options".