### PR TITLE
Fix as_dict for arrays

### DIFF
--- a/ctypeslib/data/structure_type.tpl
+++ b/ctypeslib/data/structure_type.tpl
@@ -17,11 +17,11 @@ class AsDictMixin:
             type_ = type(value)
             if hasattr(value, "_length_") and hasattr(value, "_type_"):
                 # array
-                if not hasattr(type_, "as_dict"):
-                    value = [v for v in value]
-                else:
-                    type_ = type_._type_
+                type_ = type_._type_
+                if hasattr(type_, 'as_dict'):
                     value = [type_.as_dict(v) for v in value]
+                else:
+                    value = [i for i in value]
             elif hasattr(value, "contents") and hasattr(value, "_type_"):
                 # pointer
                 try:


### PR DESCRIPTION
If the field is an array, then the field type will not have the as_dict method bound to it. The Structure describing the individual elements in the array will have the as_dict method. Because of this, hasattr(type_, "as_dict") will always return False.