### PR TITLE
anonymous structs and unions fix

### DIFF
--- a/ctypeslib/codegen/cursorhandler.py
+++ b/ctypeslib/codegen/cursorhandler.py
@@ -988,12 +988,14 @@ class CursorHandler(ClangHandler):
         # but at least with clang-17.. anonymous fields have a name "type (anonymous at ..)"
         name = cursor.spelling
         offset = parent.type.get_offset(name)
-        if (not name or "(anonymous" in name) and cursor.is_anonymous() and not cursor.is_bitfield():
+        if "(anonymous" in name:
+            name = ""
+        if not name and cursor.is_anonymous() and not cursor.is_bitfield():
             # anonymous type, that is not a bitfield field case:
             offset = cursor.get_field_offsetof()
             # name = self.get_unique_name(cursor)
             # we want to keep name empty if the field is unnamed.
-        elif not name or "(anonymous" in name:
+        elif not name:
             # anonymous bitfield case:
             # get offset by iterating all fields of parent
             # corner case for anonymous fields

--- a/ctypeslib/codegen/cursorhandler.py
+++ b/ctypeslib/codegen/cursorhandler.py
@@ -985,14 +985,15 @@ class CursorHandler(ClangHandler):
         # Note: cursor.is_anonymous seems to be unreliable/inconsistent across
         # libclang versions, and we will consider the field as anonymous if
         # cursor.spelling is empty
+        # but at least with clang-17.. anonymous fields have a name "type (anonymous at ..)"
         name = cursor.spelling
         offset = parent.type.get_offset(name)
-        if not name and cursor.is_anonymous() and not cursor.is_bitfield():
+        if (not name or "(anonymous" in name) and cursor.is_anonymous() and not cursor.is_bitfield():
             # anonymous type, that is not a bitfield field case:
             offset = cursor.get_field_offsetof()
             # name = self.get_unique_name(cursor)
             # we want to keep name empty if the field is unnamed.
-        elif not name:
+        elif not name or "(anonymous" in name:
             # anonymous bitfield case:
             # get offset by iterating all fields of parent
             # corner case for anonymous fields

--- a/ctypeslib/codegen/handler.py
+++ b/ctypeslib/codegen/handler.py
@@ -126,14 +126,14 @@ class ClangHandler(object):
 
     def get_unique_name(self, cursor, field_name=None):
         """get the spelling or create a unique name for a cursor"""
-        if cursor.kind in [CursorKind.UNEXPOSED_DECL]:
+        if cursor.kind in [CursorKind.UNEXPOSED_DECL, TypeKind.RECORD]:
             return ''
         # covers most cases
         name = cursor.spelling
         if cursor.kind == CursorKind.CXX_BASE_SPECIFIER:
             name = cursor.type.spelling
         # if it's a record decl or field decl and its type is anonymous
-        if name == '' or '(anonymous at' in name:
+        if name == '' or '(anonymous' in name:
             # if cursor.is_anonymous():
             # a unnamed object at the root TU
             if (cursor.semantic_parent

--- a/ctypeslib/codegen/handler.py
+++ b/ctypeslib/codegen/handler.py
@@ -133,7 +133,7 @@ class ClangHandler(object):
         if cursor.kind == CursorKind.CXX_BASE_SPECIFIER:
             name = cursor.type.spelling
         # if it's a record decl or field decl and its type is anonymous
-        if name == '':
+        if name == '' or '(anonymous at' in name:
             # if cursor.is_anonymous():
             # a unnamed object at the root TU
             if (cursor.semantic_parent

--- a/ctypeslib/codegen/handler.py
+++ b/ctypeslib/codegen/handler.py
@@ -1,6 +1,6 @@
 """Abstract Handler with helper methods."""
 
-from clang.cindex import CursorKind, TypeKind
+from clang.cindex import CursorKind, TypeKind, Cursor
 
 from ctypeslib.codegen import typedesc
 from ctypeslib.codegen.util import log_entity
@@ -126,14 +126,19 @@ class ClangHandler(object):
 
     def get_unique_name(self, cursor, field_name=None):
         """get the spelling or create a unique name for a cursor"""
-        if cursor.kind in [CursorKind.UNEXPOSED_DECL, TypeKind.RECORD]:
+        if not isinstance(cursor, Cursor):
+            log.warning('get_unique_name: not a cursor')
+            return ''
+        if cursor.kind in [CursorKind.UNEXPOSED_DECL]:
             return ''
         # covers most cases
         name = cursor.spelling
         if cursor.kind == CursorKind.CXX_BASE_SPECIFIER:
             name = cursor.type.spelling
         # if it's a record decl or field decl and its type is anonymous
-        if name == '' or '(anonymous' in name:
+        if cursor.is_anonymous() and '(' in name:
+            name = ''
+        if name == '':
             # if cursor.is_anonymous():
             # a unnamed object at the root TU
             if (cursor.semantic_parent

--- a/ctypeslib/codegen/util.py
+++ b/ctypeslib/codegen/util.py
@@ -114,7 +114,7 @@ def log_entity(func):
     def fn(*args, **kwargs):
         name = args[0].get_unique_name(args[1])
         if name == '':
-            parent = args[1].semantic_parent
+            parent = getattr(args[1], 'semantic_parent', None)
             if parent:
                 name = 'child of %s' % parent.displayname
         log.debug("%s: displayname:'%s'",func.__name__, name)


### PR DESCRIPTION
In at least clang-17, anonymous unions which were given no name in libclang, are now give with a name like (anonymous at filename.h:23:2).  This obviously breaks. This patch fixes the problem with a light touch that should work either way, but only tested with clang-17.   This should fix Issue #135 