### PR TITLE
cursorhandler.py: remove inaccurate warning

### DIFF
--- a/ctypeslib/codegen/cursorhandler.py
+++ b/ctypeslib/codegen/cursorhandler.py
@@ -1027,7 +1027,8 @@ class CursorHandler(ClangHandler):
         else:
             bits = cursor.type.get_size() * 8
             if bits < 0:
-                log.warning('Bad source code, bitsize == %d <0 on %s', bits, name)
+                # Flex array members have a size of -2
+                # log.warning('Bad source code, bitsize == %d <0 on %s', bits, name)
                 bits = 0
         log.debug('FIELD_DECL: field is %d bits', bits)
         # try to get a representation of the type


### PR DESCRIPTION
Fixes Issue #150 

clang gives flex array members a size of -2, which means the bad source code warning generated when checking if bits < 0 is always generated for flex arrays.

clang only assigns flex arrays a negative size. Therefore, this warning will never be generated for non flex arrays, which renders it inaccurate.